### PR TITLE
fixed a typo and suggested a replacement word

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -186,7 +186,7 @@ Regularly review progress towards policy goals. Update the policy when there are
 
 To maintain the target level of accessibility, specify a process and schedule to review content and tools in scope.
 
-Feedback from users who might find accessibility barriers can help you identify issues. Your policy should include information on how you will gather feedback. It should also include information how how your organization will handle and respond to feedback.
+Feedback from users who might find accessibility barriers can help you identify issues. Your policy should include information on how you will gather feedback. It should also include information on how your organization will handle and respond to feedback.
 
 ### Examples {#ex5}
 


### PR DESCRIPTION
changes addressed these points: 
* removed a doubled use of "how" from that sentence
* and suggesting an alternative word for that "doubled - how" with "on"

fyi: i can see how any other alternatives might suit that sentence and purpose, such as "about" instead of "on", so please have your assessment regarding it and suggest if there is an use for a better "alternative" for that instance. thanks for looking into this, much appreciated :)